### PR TITLE
FIX: CSS Class names 💯

### DIFF
--- a/step-02/editor.css
+++ b/step-02/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-boilerplate-es5-hello-world-step-02 {
+.wp-block-gutenberg-boilerplate-es-5-hello-world-step-02 {
 	color: green;
 	background: #cfc;
 	border: 2px solid #9c9;

--- a/step-02/style.css
+++ b/step-02/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-boilerplate-es5-hello-world-step-02 {
+.wp-block-gutenberg-boilerplate-es-5-hello-world-step-02 {
 	color: darkred;
 	background: #fcc;
 	border: 2px solid #c99;

--- a/step-03/editor.css
+++ b/step-03/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-boilerplate-es5-hello-world-step-03 {
+.wp-block-gutenberg-boilerplate-es-5-hello-world-step-03 {
 	color: green;
 	background: #cfc;
 	border: 2px solid #9c9;

--- a/step-03/style.css
+++ b/step-03/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-boilerplate-es5-hello-world-step-03 {
+.wp-block-gutenberg-boilerplate-es-5-hello-world-step-03 {
 	color: darkred;
 	background: #fcc;
 	border: 2px solid #c99;

--- a/step-04/editor.css
+++ b/step-04/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-boilerplate-es5-hello-world-step-04 {
+.wp-block-gutenberg-boilerplate-es-5-hello-world-step-04 {
 	color: green;
 	background: #cfc;
 	border: 2px solid #9c9;

--- a/step-04/style.css
+++ b/step-04/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-gutenberg-boilerplate-es5-hello-world-step-04 {
+.wp-block-gutenberg-boilerplate-es-5-hello-world-step-04 {
 	color: darkred;
 	background: #fcc;
 	border: 2px solid #c99;


### PR DESCRIPTION
The CSS class names in `.css` files were wrong. This PR fixes them.